### PR TITLE
Fixed aperture bounding boxes ignoring the internal transformation

### DIFF
--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -1,5 +1,6 @@
 import abc
 import dataclasses
+import functools
 import numpy as np
 import numpy.typing as npt
 import matplotlib.axes
@@ -489,13 +490,71 @@ class CircularSectorAperture(
 
         return mask
 
+    def _bound_extrema(
+        self,
+    ) -> tuple[na.Cartesian3dVectorArray, na.Cartesian3dVectorArray]:
+        """
+        Compute the axis-aligned bounding box of this aperture analytically.
+
+        The extremum of the sector along a given world axis is attained
+        either at the apex, at one of the two endpoints of the arc, or at an
+        interior point of the arc where the boundary is tangent to the world
+        axis, if that point lies within the angular range of the sector.
+        """
+        radius = self.radius
+        angle_start = self.angle_start
+        angle_stop = self.angle_stop
+
+        zero = 0 * radius
+        apex = na.Cartesian3dVectorArray(x=zero, y=zero, z=zero)
+        axis_a = na.Cartesian3dVectorArray(x=radius, y=zero, z=zero)
+        axis_b = na.Cartesian3dVectorArray(x=zero, y=radius, z=zero)
+        if self.transformation is not None:
+            apex = self.transformation(apex)
+            axis_a = self.transformation(axis_a) - apex
+            axis_b = self.transformation(axis_b) - apex
+
+        span = (angle_stop - angle_start) % (360 * u.deg)
+
+        result_lower = na.Cartesian3dVectorArray()
+        result_upper = na.Cartesian3dVectorArray()
+        for c in ("x", "y", "z"):
+            center = getattr(apex, c)
+            coeff_a = getattr(axis_a, c)
+            coeff_b = getattr(axis_b, c)
+
+            point_start = center + coeff_a * np.cos(angle_start)
+            point_start = point_start + coeff_b * np.sin(angle_start)
+            point_stop = center + coeff_a * np.cos(angle_stop)
+            point_stop = point_stop + coeff_b * np.sin(angle_stop)
+
+            candidates = [center, point_start, point_stop]
+
+            # interior extrema of the arc along this axis, kept only if they
+            # lie within the angular range of the sector
+            angle_critical = np.arctan2(coeff_b, coeff_a)
+            if na.unit(angle_critical) is None:
+                angle_critical = angle_critical * u.rad
+            for angle in (angle_critical, angle_critical + 180 * u.deg):
+                point_angle = center + coeff_a * np.cos(angle)
+                point_angle = point_angle + coeff_b * np.sin(angle)
+                where = ((angle - angle_start) % (360 * u.deg)) <= span
+                candidates.append(np.where(where, point_angle, point_start))
+
+            setattr(result_lower, c, functools.reduce(np.minimum, candidates))
+            setattr(result_upper, c, functools.reduce(np.maximum, candidates))
+
+        return result_lower, result_upper
+
     @property
     def bound_lower(self) -> na.Cartesian3dVectorArray:
-        return self.wire().min()
+        lower, upper = self._bound_extrema()
+        return lower
 
     @property
     def bound_upper(self) -> na.Cartesian3dVectorArray:
-        return self.wire().max()
+        lower, upper = self._bound_extrema()
+        return upper
 
     @property
     def vertices(self) -> None:
@@ -635,21 +694,16 @@ class EllipticalAperture(
         :math:`\\max_t (A \\cos t + B \\sin t) = \\sqrt{A^2 + B^2}`.
         """
         radius = self.radius
-        zero = na.Cartesian3dVectorArray() * radius.x
-        axis_a = na.Cartesian3dVectorArray(x=radius.x, y=0 * radius.x, z=0 * radius.x)
-        axis_b = na.Cartesian3dVectorArray(x=0 * radius.y, y=radius.y, z=0 * radius.y)
+        center = na.Cartesian3dVectorArray() << radius.x.unit
+        axis_a = na.Cartesian3dVectorArray(x=radius.x) << radius.x.unit
+        axis_b = na.Cartesian3dVectorArray(y=radius.y) << radius.y.unit
 
-        center = zero
         if self.transformation is not None:
-            center = self.transformation(zero)
+            center = self.transformation(center)
             axis_a = self.transformation(axis_a) - center
             axis_b = self.transformation(axis_b) - center
 
-        half = na.Cartesian3dVectorArray(
-            x=np.sqrt(np.square(axis_a.x) + np.square(axis_b.x)),
-            y=np.sqrt(np.square(axis_a.y) + np.square(axis_b.y)),
-            z=np.sqrt(np.square(axis_a.z) + np.square(axis_b.z)),
-        )
+        half = np.sqrt(np.square(axis_a) + np.square(axis_b))
         return center, half
 
     @property

--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -620,27 +620,11 @@ class EllipticalAperture(
 
     @property
     def bound_lower(self) -> na.Cartesian3dVectorArray:
-        unit = na.unit(self.radius)
-        result = na.Cartesian3dVectorArray()
-        if unit is not None:
-            result = result * unit
-        if self.transformation is not None:
-            result = self.transformation(result)
-        result.x = result.x - self.radius.x
-        result.y = result.y - self.radius.y
-        return result
+        return self.wire().min()
 
     @property
     def bound_upper(self) -> na.Cartesian3dVectorArray:
-        unit = na.unit(self.radius)
-        result = na.Cartesian3dVectorArray()
-        if unit is not None:
-            result = result * unit
-        if self.transformation is not None:
-            result = self.transformation(result)
-        result.x = result.x + self.radius.x
-        result.y = result.y + self.radius.y
-        return result
+        return self.wire().max()
 
     @property
     def vertices(self) -> None:
@@ -717,11 +701,17 @@ class AbstractPolygonalAperture(
 
     @property
     def bound_lower(self) -> na.AbstractCartesian3dVectorArray:
-        return self.vertices.min(axis="vertex")
+        vertices = self.vertices
+        if self.transformation is not None:
+            vertices = self.transformation(vertices)
+        return vertices.min(axis="vertex")
 
     @property
     def bound_upper(self) -> na.AbstractCartesian3dVectorArray:
-        return self.vertices.max(axis="vertex")
+        vertices = self.vertices
+        if self.transformation is not None:
+            vertices = self.transformation(vertices)
+        return vertices.max(axis="vertex")
 
     def wire(self, num: None | int = None) -> na.Cartesian3dVectorArray:
         if num is None:
@@ -874,24 +864,24 @@ class RectangularAperture(
         self,
         position: na.AbstractCartesian3dVectorArray,
     ) -> na.AbstractScalar:
-        bound_lower = self.bound_lower
-        bound_upper = self.bound_upper
+        half_width = na.asanyarray(
+            self.half_width,
+            like=na.Cartesian2dVectorArray(),
+        )
         active = self.active
         inverted = self.inverted
         if self.transformation is not None:
             position = self.transformation.inverse(position)
+        position = position.xy
 
-        shape = na.shape_broadcasted(
-            bound_lower, bound_upper, active, inverted, position
-        )
+        shape = na.shape_broadcasted(half_width, active, inverted, position)
 
-        bound_lower = na.broadcast_to(bound_lower, shape)
-        bound_upper = na.broadcast_to(bound_upper, shape)
+        half_width = na.broadcast_to(half_width, shape)
         active = na.broadcast_to(active, shape)
         inverted = na.broadcast_to(inverted, shape)
         position = na.broadcast_to(position, shape)
 
-        mask = (bound_lower <= position) & (position <= bound_upper)
+        mask = (-half_width <= position) & (position <= half_width)
         mask = mask.x & mask.y
 
         mask[inverted] = ~mask[inverted]

--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -618,13 +618,49 @@ class EllipticalAperture(
 
         return mask
 
+    def _bound_center_half(
+        self,
+    ) -> tuple[na.Cartesian3dVectorArray, na.Cartesian3dVectorArray]:
+        """
+        The center and per-component half-extent of the axis-aligned bounding
+        box, computed analytically so the bound is exact even when
+        :attr:`transformation` rotates the ellipse.
+
+        A point on the ellipse boundary is
+        :math:`p(t) = c + a\\,\\hat{e}_a \\cos t + b\\,\\hat{e}_b \\sin t`,
+        where :math:`c` is the center and :math:`\\hat{e}_a, \\hat{e}_b` are the
+        images of the local axes under the transformation.  The extent along
+        any world component is then
+        :math:`\\sqrt{(a\\,\\hat{e}_a)^2 + (b\\,\\hat{e}_b)^2}`, since
+        :math:`\\max_t (A \\cos t + B \\sin t) = \\sqrt{A^2 + B^2}`.
+        """
+        radius = self.radius
+        zero = na.Cartesian3dVectorArray() * radius.x
+        axis_a = na.Cartesian3dVectorArray(x=radius.x, y=0 * radius.x, z=0 * radius.x)
+        axis_b = na.Cartesian3dVectorArray(x=0 * radius.y, y=radius.y, z=0 * radius.y)
+
+        center = zero
+        if self.transformation is not None:
+            center = self.transformation(zero)
+            axis_a = self.transformation(axis_a) - center
+            axis_b = self.transformation(axis_b) - center
+
+        half = na.Cartesian3dVectorArray(
+            x=np.sqrt(np.square(axis_a.x) + np.square(axis_b.x)),
+            y=np.sqrt(np.square(axis_a.y) + np.square(axis_b.y)),
+            z=np.sqrt(np.square(axis_a.z) + np.square(axis_b.z)),
+        )
+        return center, half
+
     @property
     def bound_lower(self) -> na.Cartesian3dVectorArray:
-        return self.wire().min()
+        center, half = self._bound_center_half()
+        return center - half
 
     @property
     def bound_upper(self) -> na.Cartesian3dVectorArray:
-        return self.wire().max()
+        center, half = self._bound_center_half()
+        return center + half
 
     @property
     def vertices(self) -> None:

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -1,3 +1,4 @@
+import dataclasses
 import pytest
 import numpy as np
 import matplotlib.axes
@@ -83,24 +84,32 @@ class AbstractTestAbstractAperture(
     def test_bound_lower(self, a: optika.apertures.AbstractAperture):
         result = a.bound_lower
         assert isinstance(result, na.AbstractCartesian3dVectorArray)
-        wire = a.wire()
+        # a densely-sampled wire approaches the true extent from the inside
+        wire = a.wire(num=10001)
         for component in ("x", "y"):
             bound = getattr(result, component)
             edge = getattr(wire, component).min("wire")
-            tolerance = 1e-9 * (np.abs(bound) + np.abs(edge))
-            assert np.all(bound <= edge + tolerance)
+            scale = np.abs(getattr(a.bound_upper, component) - bound)
+            # the bound must enclose the wire ...
+            assert np.all(bound <= edge + 1e-9 * scale)
+            # ... and be tight: it must not undershoot the true extent
+            assert np.all(np.abs(bound - edge) < 1e-6 * scale)
 
     def test_bound_upper(self, a: optika.apertures.AbstractAperture):
         result = a.bound_upper
         assert isinstance(result, na.AbstractCartesian3dVectorArray)
         assert np.all(result.x != a.bound_lower.x)
         assert np.all(result.y != a.bound_lower.y)
-        wire = a.wire()
+        # a densely-sampled wire approaches the true extent from the inside
+        wire = a.wire(num=10001)
         for component in ("x", "y"):
             bound = getattr(result, component)
             edge = getattr(wire, component).max("wire")
-            tolerance = 1e-9 * (np.abs(bound) + np.abs(edge))
-            assert np.all(bound >= edge - tolerance)
+            scale = np.abs(bound - getattr(a.bound_lower, component))
+            # the bound must enclose the wire ...
+            assert np.all(bound >= edge - 1e-9 * scale)
+            # ... and be tight: it must not overshoot the true extent
+            assert np.all(np.abs(bound - edge) < 1e-6 * scale)
 
     def test_vertices(self, a: optika.apertures.AbstractAperture):
         if a.vertices is not None:
@@ -311,6 +320,37 @@ class TestRectangularAperture(
         assert isinstance(a.half_width, types_valid)
         assert np.all(a.half_width >= 0)
 
+    def test_decentered(self, a: optika.apertures.RectangularAperture):
+        """
+        A rectangular aperture decentered by more than its width must accept
+        the center of the translated rectangle and reject the center of the
+        untranslated one.
+
+        Regression test: ``RectangularAperture.__call__`` used to express the
+        rectangle in terms of :attr:`bound_lower`/:attr:`bound_upper` while
+        also inverse-transforming the position, applying the internal
+        transformation twice.
+        """
+        if (a.active is not True) or (a.inverted is not False):
+            return
+        half_width = a.half_width
+        if isinstance(half_width, na.AbstractCartesian2dVectorArray):
+            half_width = half_width.x
+        decenter = 3 * half_width
+        zero = 0 * decenter
+        b = dataclasses.replace(
+            a,
+            transformation=na.transformations.Cartesian3dTranslation(
+                x=decenter,
+                y=zero,
+                z=zero,
+            ),
+        )
+        point_inside = na.Cartesian3dVectorArray(x=decenter, y=zero, z=zero)
+        point_outside = na.Cartesian3dVectorArray(x=zero, y=zero, z=zero)
+        assert np.all(b(point_inside))
+        assert not np.any(b(point_outside))
+
 
 class AbstractTestAbstractRegularPolygonalAperture(
     AbstractTestAbstractPolygonalAperture,
@@ -420,67 +460,3 @@ class TestIsoscelesTrapezoidalAperture(
     AbstractTestAbstractIsoscelesTrapezoidalAperture,
 ):
     pass
-
-
-def test_rectangular_aperture_decentered():
-    """
-    A rectangular aperture decentered by its internal transformation must
-    accept points inside the translated rectangle and reject points inside
-    the untranslated one.
-
-    Regression test: ``RectangularAperture.__call__`` used to express the
-    rectangle in terms of :attr:`bound_lower`/:attr:`bound_upper` while
-    also inverse-transforming the position, applying the internal
-    transformation twice.
-    """
-    half_width = 5 * u.mm
-    decenter = 12 * u.mm
-    a = optika.apertures.RectangularAperture(
-        half_width=half_width,
-        transformation=na.transformations.Cartesian3dTranslation(x=decenter),
-    )
-    point_inside = na.Cartesian3dVectorArray(12, 0, 0) * u.mm
-    point_outside = na.Cartesian3dVectorArray(0, 0, 0) * u.mm
-    assert np.all(na.as_named_array(a(point_inside)))
-    assert not np.any(na.as_named_array(a(point_outside)))
-
-
-def test_elliptical_aperture_bounds_analytic():
-    """
-    The bounding box of a rotated, decentered elliptical aperture is computed
-    analytically and must match the true extent of the ellipse.
-
-    Regression test: the bounds used to be sampled from a coarse
-    :meth:`wire`, which underestimates the extent between samples whenever the
-    transformation rotates the ellipse off the coordinate axes.
-    """
-    a = optika.apertures.EllipticalAperture(
-        radius=na.Cartesian2dVectorArray(100, 50) * u.mm,
-        transformation=(
-            na.transformations.Cartesian3dRotationZ(30 * u.deg)
-            @ na.transformations.Cartesian3dTranslation(x=5 * u.mm, y=-2 * u.mm)
-        ),
-    )
-
-    bound_lower = a.bound_lower
-    bound_upper = a.bound_upper
-
-    # a densely-sampled wire approaches the true extent from the inside
-    wire = a.wire(num=100001)
-    for component in ("x", "y"):
-        lower = getattr(bound_lower, component)
-        upper = getattr(bound_upper, component)
-        edge_lower = getattr(wire, component).min("wire")
-        edge_upper = getattr(wire, component).max("wire")
-        scale = np.abs(upper - lower)
-
-        # the analytic bound encloses the dense wire ...
-        assert np.all(lower <= edge_lower + 1e-9 * scale)
-        assert np.all(upper >= edge_upper - 1e-9 * scale)
-        # ... and is tight: it does not overshoot it
-        assert np.all(np.abs(lower - edge_lower) < 1e-6 * scale)
-        assert np.all(np.abs(upper - edge_upper) < 1e-6 * scale)
-
-    # an in-plane rotation leaves the aperture flat in z
-    assert np.all(bound_lower.z == 0 * u.mm)
-    assert np.all(bound_upper.z == 0 * u.mm)

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -25,12 +25,6 @@ transform_parameterization = [
 ]
 
 
-def _nominal(x: na.AbstractScalar) -> na.AbstractScalar:
-    if isinstance(x, na.AbstractUncertainScalarArray):
-        return x.nominal
-    return x
-
-
 class AbstractTestAbstractAperture(
     test_mixins.AbstractTestDxfWritable,
     test_mixins.AbstractTestPrintable,
@@ -67,12 +61,7 @@ class AbstractTestAbstractAperture(
         # aperture (every aperture here is star-shaped about its centroid)
         if (a.active is True) and (a.inverted is False):
             centroid = a.wire().mean("wire")
-            centroid = na.Cartesian3dVectorArray(
-                x=_nominal(centroid.x),
-                y=_nominal(centroid.y),
-                z=_nominal(centroid.z),
-            )
-            assert np.all(_nominal(na.as_named_array(a(centroid))))
+            assert np.all(na.as_named_array(a(centroid)))
 
     @pytest.mark.parametrize("rays", optika.rays._tests.test_ray_vectors.rays)
     def test_clip_rays(
@@ -94,12 +83,10 @@ class AbstractTestAbstractAperture(
     def test_bound_lower(self, a: optika.apertures.AbstractAperture):
         result = a.bound_lower
         assert isinstance(result, na.AbstractCartesian3dVectorArray)
-        # compare nominal values only, since uncertain parameters may be
-        # redrawn between independent evaluations of the geometry
         wire = a.wire()
         for component in ("x", "y"):
-            bound = _nominal(getattr(result, component))
-            edge = _nominal(getattr(wire, component).min("wire"))
+            bound = getattr(result, component)
+            edge = getattr(wire, component).min("wire")
             tolerance = 1e-9 * (np.abs(bound) + np.abs(edge))
             assert np.all(bound <= edge + tolerance)
 
@@ -110,8 +97,8 @@ class AbstractTestAbstractAperture(
         assert np.all(result.y != a.bound_lower.y)
         wire = a.wire()
         for component in ("x", "y"):
-            bound = _nominal(getattr(result, component))
-            edge = _nominal(getattr(wire, component).max("wire"))
+            bound = getattr(result, component)
+            edge = getattr(wire, component).max("wire")
             tolerance = 1e-9 * (np.abs(bound) + np.abs(edge))
             assert np.all(bound >= edge - tolerance)
 

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -25,6 +25,12 @@ transform_parameterization = [
 ]
 
 
+def _nominal(x: na.AbstractScalar) -> na.AbstractScalar:
+    if isinstance(x, na.AbstractUncertainScalarArray):
+        return x.nominal
+    return x
+
+
 class AbstractTestAbstractAperture(
     test_mixins.AbstractTestDxfWritable,
     test_mixins.AbstractTestPrintable,
@@ -57,6 +63,17 @@ class AbstractTestAbstractAperture(
 
         assert np.all(result[~na.as_named_array(a.active)])
 
+        # the centroid of the wire must be inside an active, non-inverted
+        # aperture (every aperture here is star-shaped about its centroid)
+        if (a.active is True) and (a.inverted is False):
+            centroid = a.wire().mean("wire")
+            centroid = na.Cartesian3dVectorArray(
+                x=_nominal(centroid.x),
+                y=_nominal(centroid.y),
+                z=_nominal(centroid.z),
+            )
+            assert np.all(_nominal(na.as_named_array(a(centroid))))
+
     @pytest.mark.parametrize("rays", optika.rays._tests.test_ray_vectors.rays)
     def test_clip_rays(
         self,
@@ -75,12 +92,28 @@ class AbstractTestAbstractAperture(
         assert np.mean(result.unvignetted) <= np.mean(rays.unvignetted)
 
     def test_bound_lower(self, a: optika.apertures.AbstractAperture):
-        assert isinstance(a.bound_lower, na.AbstractCartesian3dVectorArray)
+        result = a.bound_lower
+        assert isinstance(result, na.AbstractCartesian3dVectorArray)
+        # compare nominal values only, since uncertain parameters may be
+        # redrawn between independent evaluations of the geometry
+        wire = a.wire()
+        for component in ("x", "y"):
+            bound = _nominal(getattr(result, component))
+            edge = _nominal(getattr(wire, component).min("wire"))
+            tolerance = 1e-9 * (np.abs(bound) + np.abs(edge))
+            assert np.all(bound <= edge + tolerance)
 
     def test_bound_upper(self, a: optika.apertures.AbstractAperture):
-        assert isinstance(a.bound_upper, na.AbstractCartesian3dVectorArray)
-        assert np.all(a.bound_upper.x != a.bound_lower.x)
-        assert np.all(a.bound_upper.y != a.bound_lower.y)
+        result = a.bound_upper
+        assert isinstance(result, na.AbstractCartesian3dVectorArray)
+        assert np.all(result.x != a.bound_lower.x)
+        assert np.all(result.y != a.bound_lower.y)
+        wire = a.wire()
+        for component in ("x", "y"):
+            bound = _nominal(getattr(result, component))
+            edge = _nominal(getattr(wire, component).max("wire"))
+            tolerance = 1e-9 * (np.abs(bound) + np.abs(edge))
+            assert np.all(bound >= edge - tolerance)
 
     def test_vertices(self, a: optika.apertures.AbstractAperture):
         if a.vertices is not None:
@@ -400,3 +433,26 @@ class TestIsoscelesTrapezoidalAperture(
     AbstractTestAbstractIsoscelesTrapezoidalAperture,
 ):
     pass
+
+
+def test_rectangular_aperture_decentered():
+    """
+    A rectangular aperture decentered by its internal transformation must
+    accept points inside the translated rectangle and reject points inside
+    the untranslated one.
+
+    Regression test: ``RectangularAperture.__call__`` used to express the
+    rectangle in terms of :attr:`bound_lower`/:attr:`bound_upper` while
+    also inverse-transforming the position, applying the internal
+    transformation twice.
+    """
+    half_width = 5 * u.mm
+    decenter = 12 * u.mm
+    a = optika.apertures.RectangularAperture(
+        half_width=half_width,
+        transformation=na.transformations.Cartesian3dTranslation(x=decenter),
+    )
+    point_inside = na.Cartesian3dVectorArray(12, 0, 0) * u.mm
+    point_outside = na.Cartesian3dVectorArray(0, 0, 0) * u.mm
+    assert np.all(na.as_named_array(a(point_inside)))
+    assert not np.any(na.as_named_array(a(point_outside)))

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -456,3 +456,44 @@ def test_rectangular_aperture_decentered():
     point_outside = na.Cartesian3dVectorArray(0, 0, 0) * u.mm
     assert np.all(na.as_named_array(a(point_inside)))
     assert not np.any(na.as_named_array(a(point_outside)))
+
+
+def test_elliptical_aperture_bounds_analytic():
+    """
+    The bounding box of a rotated, decentered elliptical aperture is computed
+    analytically and must match the true extent of the ellipse.
+
+    Regression test: the bounds used to be sampled from a coarse
+    :meth:`wire`, which underestimates the extent between samples whenever the
+    transformation rotates the ellipse off the coordinate axes.
+    """
+    a = optika.apertures.EllipticalAperture(
+        radius=na.Cartesian2dVectorArray(100, 50) * u.mm,
+        transformation=(
+            na.transformations.Cartesian3dRotationZ(30 * u.deg)
+            @ na.transformations.Cartesian3dTranslation(x=5 * u.mm, y=-2 * u.mm)
+        ),
+    )
+
+    bound_lower = a.bound_lower
+    bound_upper = a.bound_upper
+
+    # a densely-sampled wire approaches the true extent from the inside
+    wire = a.wire(num=100001)
+    for component in ("x", "y"):
+        lower = getattr(bound_lower, component)
+        upper = getattr(bound_upper, component)
+        edge_lower = getattr(wire, component).min("wire")
+        edge_upper = getattr(wire, component).max("wire")
+        scale = np.abs(upper - lower)
+
+        # the analytic bound encloses the dense wire ...
+        assert np.all(lower <= edge_lower + 1e-9 * scale)
+        assert np.all(upper >= edge_upper - 1e-9 * scale)
+        # ... and is tight: it does not overshoot it
+        assert np.all(np.abs(lower - edge_lower) < 1e-6 * scale)
+        assert np.all(np.abs(upper - edge_upper) < 1e-6 * scale)
+
+    # an in-plane rotation leaves the aperture flat in z
+    assert np.all(bound_lower.z == 0 * u.mm)
+    assert np.all(bound_upper.z == 0 * u.mm)


### PR DESCRIPTION
## Summary

`AbstractPolygonalAperture.bound_lower`/`bound_upper` were computed from the raw vertices, while `__call__` and `wire()` apply the aperture's internal `transformation`. For apertures with a nonzero internal transformation (e.g. a decentered grating aperture), every consumer of the bounding box (stratified sampling grids, sensor pixel grids, pupil normalization) saw the wrong region of the surface.

Found while validating a physical-optics model of ESIS f1: the grating's trapezoidal aperture is decentered by `-12.26 mm`, so the sampling grid only overlapped a ~4.7 mm sliver of the real 16.9 mm aperture, broadening the Huygens PSF by 4x in the dispersion direction.

Related defects fixed in the same PR:

- `EllipticalAperture` bounds transformed only the bounding-box corner points, which is incorrect under rotation. They are now closed-form: a boundary point is `c + a*e_a*cos(t) + b*e_b*sin(t)`, so the extent along each world axis is `sqrt((a*e_a)^2 + (b*e_b)^2)`, exact under rotation.
- `RectangularAperture.__call__` expressed the rectangle in terms of `bound_lower`/`bound_upper` while *also* inverse-transforming the position, which double-counts the internal transformation once the bounds include it; it now tests against `half_width` directly.
- `CircularSectorAperture` bounds were the min/max of the default coarse wire, underestimating the true extent (up to ~2% with the default 21 samples). They are now analytic: the extremum along each world axis is attained at the apex, an arc endpoint, or an interior point of the arc where the boundary is tangent to that axis, clamped to the angular range of the sector.

## Tests

The generic bound tests now assert, for every aperture type, that the bounds enclose a densely-sampled wire and are tight against it (which is what exposed the `CircularSectorAperture` defect), and that the wire centroid is accepted by active, non-inverted apertures. The decentered-`RectangularAperture` double-transformation regression is generalized over every parametrized instance in `TestRectangularAperture.test_decentered`.

All comparisons use full uncertain arrays: random implicit arrays fix their seed at construction, so independent evaluations of the same geometry are reproducible and per-sample comparisons are safe.

`pytest optika/apertures`: 20665 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc