### PR TITLE
Added `SequentialSystem.vignetting()`, a method to fit a polynomial vignetting model

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1152,34 +1152,13 @@ class AbstractSequentialSystem(
         degree
             The degree of the polynomial distortion model.
         """
-        if wavelength is None and field is None and pupil is None:
-            rays = self.rayfunction_default
-            axis_wavelength = self.axis_wavelength_
-            axis_field = self.axis_field_
-            axis_pupil = self.axis_pupil_
-        else:
-            rays = self.rayfunction(
-                wavelength=wavelength,
-                field=field,
-                pupil=pupil,
-                normalized_field=normalized_field,
-                normalized_pupil=normalized_pupil,
-            )
-            axis_wavelength = self._normalize_axis_wavelength(
-                axis_wavelength=None,
-                wavelength=rays.inputs.wavelength,
-            )
-            axis_field = self._normalize_axis_field(
-                axis_field=None,
-                axis_wavelength=axis_wavelength,
-                field=rays.inputs.field,
-            )
-            axis_pupil = self._normalize_axis_pupil(
-                axis_pupil=None,
-                axis_field=axis_field,
-                axis_wavelength=axis_wavelength,
-                pupil=rays.inputs.pupil,
-            )
+        rays, axis_wavelength, axis_field, axis_pupil = self._rayfunction_and_axes(
+            wavelength=wavelength,
+            field=field,
+            pupil=pupil,
+            normalized_field=normalized_field,
+            normalized_pupil=normalized_pupil,
+        )
 
         if not axis_wavelength:
             raise ValueError(
@@ -1213,6 +1192,149 @@ class AbstractSequentialSystem(
             degree=degree,
             where=where,
         )
+
+    def vignetting(
+        self,
+        wavelength: None | u.Quantity | na.AbstractScalar = None,
+        field: None | na.AbstractCartesian2dVectorArray = None,
+        pupil: None | na.AbstractCartesian2dVectorArray = None,
+        normalized_field: bool = True,
+        normalized_pupil: bool = True,
+        degree: int = 2,
+    ) -> optika.radiometry.PolynomialVignettingModel:
+        """
+        Fit a polynomial vignetting model to the rays traced through this
+        system.
+
+        The relative illumination at each scene coordinate is estimated from
+        the fraction of unvignetted rays in the pupil, normalized to its
+        maximum over the field of view.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelengths of the input rays.
+            If :obj:`None` (the default), ``self.grid_input.wavelength``
+            will be used.
+        field
+            The field positions of the input rays, in either normalized or
+            physical units.
+            If :obj:`None` (the default), ``self.grid_input.field``
+            will be used.
+        pupil
+            The pupil positions of the input rays, in either normalized or
+            physical units.
+            If :obj:`None` (the default), ``self.grid_input.pupil``
+            will be used.
+        normalized_field
+            A boolean flag indicating whether the `field` parameter is given
+            in normalized or physical units.
+        normalized_pupil
+            A boolean flag indicating whether the `pupil` parameter is given
+            in normalized or physical units.
+        degree
+            The degree of the polynomial vignetting model.
+        """
+        rays, axis_wavelength, axis_field, axis_pupil = self._rayfunction_and_axes(
+            wavelength=wavelength,
+            field=field,
+            pupil=pupil,
+            normalized_field=normalized_field,
+            normalized_pupil=normalized_pupil,
+        )
+
+        if not axis_wavelength:
+            raise ValueError(
+                "fitting a vignetting model requires the wavelength grid "
+                "to vary along its own logical axis."
+            )
+        (axis_wavelength,) = axis_wavelength
+
+        coordinates_scene = na.SpectralPositionalVectorArray(
+            wavelength=rays.inputs.wavelength,
+            position=rays.inputs.field,
+        )
+
+        illumination = rays.outputs.unvignetted.mean(axis_pupil)
+        illumination = illumination / illumination.max(axis_field)
+
+        return optika.radiometry.PolynomialVignettingModel(
+            coordinates_scene=coordinates_scene,
+            illumination=illumination,
+            axis_wavelength=axis_wavelength,
+            axis_field=axis_field,
+            degree=degree,
+        )
+
+    def _rayfunction_and_axes(
+        self,
+        wavelength: None | u.Quantity | na.AbstractScalar = None,
+        field: None | na.AbstractCartesian2dVectorArray = None,
+        pupil: None | na.AbstractCartesian2dVectorArray = None,
+        normalized_field: bool = True,
+        normalized_pupil: bool = True,
+    ) -> tuple[
+        optika.rays.RayFunctionArray,
+        tuple[str, ...],
+        tuple[str, str],
+        tuple[str, str],
+    ]:
+        """
+        Trace the given grids through this system and return the resulting
+        rays along with the normalized wavelength, field, and pupil axes.
+
+        If all of the grids are :obj:`None`, :attr:`rayfunction_default` and
+        the normalized axes of :attr:`grid_input` are used.
+        Otherwise, the rays are computed with :meth:`rayfunction` and the
+        axes are inferred from the resulting inputs, so that grids left as
+        :obj:`None` inherit the corresponding component of :attr:`grid_input`.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelengths of the input rays.
+        field
+            The field positions of the input rays, in either normalized or
+            physical units.
+        pupil
+            The pupil positions of the input rays, in either normalized or
+            physical units.
+        normalized_field
+            A boolean flag indicating whether the `field` parameter is given
+            in normalized or physical units.
+        normalized_pupil
+            A boolean flag indicating whether the `pupil` parameter is given
+            in normalized or physical units.
+        """
+        if wavelength is None and field is None and pupil is None:
+            rays = self.rayfunction_default
+            axis_wavelength = self.axis_wavelength_
+            axis_field = self.axis_field_
+            axis_pupil = self.axis_pupil_
+        else:
+            rays = self.rayfunction(
+                wavelength=wavelength,
+                field=field,
+                pupil=pupil,
+                normalized_field=normalized_field,
+                normalized_pupil=normalized_pupil,
+            )
+            axis_wavelength = self._normalize_axis_wavelength(
+                axis_wavelength=None,
+                wavelength=rays.inputs.wavelength,
+            )
+            axis_field = self._normalize_axis_field(
+                axis_field=None,
+                axis_wavelength=axis_wavelength,
+                field=rays.inputs.field,
+            )
+            axis_pupil = self._normalize_axis_pupil(
+                axis_pupil=None,
+                axis_field=axis_field,
+                axis_wavelength=axis_wavelength,
+                pupil=rays.inputs.pupil,
+            )
+        return rays, axis_wavelength, axis_field, axis_pupil
 
     def plot(
         self,

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1209,6 +1209,8 @@ class AbstractSequentialSystem(
         The relative illumination at each scene coordinate is estimated from
         the fraction of unvignetted rays in the pupil, normalized so that its
         average over the field of view is unity.
+        Field points with no unvignetted rays are excluded from the fit and
+        from the normalization.
 
         Parameters
         ----------
@@ -1255,8 +1257,15 @@ class AbstractSequentialSystem(
             position=rays.inputs.field,
         )
 
-        illumination = rays.outputs.unvignetted.mean(axis_pupil)
-        illumination = illumination / illumination.mean(axis_field)
+        unvignetted = rays.outputs.unvignetted
+        where = unvignetted.any(axis_pupil)
+
+        illumination = unvignetted.mean(axis_pupil)
+        illumination = illumination / np.mean(
+            illumination,
+            axis=axis_field,
+            where=where,
+        )
 
         return optika.radiometry.PolynomialVignettingModel(
             coordinates_scene=coordinates_scene,
@@ -1264,6 +1273,7 @@ class AbstractSequentialSystem(
             axis_wavelength=axis_wavelength,
             axis_field=axis_field,
             degree=degree,
+            where=where,
         )
 
     def _rayfunction_and_axes(

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1207,8 +1207,8 @@ class AbstractSequentialSystem(
         system.
 
         The relative illumination at each scene coordinate is estimated from
-        the fraction of unvignetted rays in the pupil, normalized to its
-        maximum over the field of view.
+        the fraction of unvignetted rays in the pupil, normalized so that its
+        average over the field of view is unity.
 
         Parameters
         ----------
@@ -1256,7 +1256,7 @@ class AbstractSequentialSystem(
         )
 
         illumination = rays.outputs.unvignetted.mean(axis_pupil)
-        illumination = illumination / illumination.max(axis_field)
+        illumination = illumination / illumination.mean(axis_field)
 
         return optika.radiometry.PolynomialVignettingModel(
             coordinates_scene=coordinates_scene,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -342,7 +342,7 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(result, optika.radiometry.PolynomialVignettingModel)
         assert result.degree == degree
         assert np.all(result.illumination >= 0)
-        assert np.all(result.illumination <= 1)
+        assert np.allclose(result.illumination.mean(result.axis_field), 1)
 
     def test_spot_diagram(self, a: optika.systems.AbstractSequentialSystem):
         fig, axs = a.spot_diagram()

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -290,6 +290,60 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(result, optika.distortion.PolynomialDistortionModel)
         assert result.degree == degree
 
+    @pytest.mark.parametrize(
+        argnames="wavelength,field,pupil",
+        argvalues=[
+            (
+                None,
+                None,
+                None,
+            ),
+            (
+                na.linspace(500, 600, axis="wavelength", num=3) * u.nm,
+                na.Cartesian2dVectorLinearSpace(
+                    start=-1,
+                    stop=1,
+                    axis=na.Cartesian2dVectorArray("field_x", "field_y"),
+                    num=5,
+                ),
+                na.Cartesian2dVectorLinearSpace(
+                    start=-1,
+                    stop=1,
+                    axis=na.Cartesian2dVectorArray("pupil_x", "pupil_y"),
+                    num=5,
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("degree", [1, 2])
+    def test_vignetting(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+        wavelength: None | u.Quantity | na.AbstractScalar,
+        field: None | na.AbstractCartesian2dVectorArray,
+        pupil: None | na.AbstractCartesian2dVectorArray,
+        degree: int,
+    ):
+        if wavelength is None and not a.axis_wavelength_:
+            with pytest.raises(ValueError):
+                a.vignetting(
+                    wavelength=wavelength,
+                    field=field,
+                    pupil=pupil,
+                    degree=degree,
+                )
+            return
+        result = a.vignetting(
+            wavelength=wavelength,
+            field=field,
+            pupil=pupil,
+            degree=degree,
+        )
+        assert isinstance(result, optika.radiometry.PolynomialVignettingModel)
+        assert result.degree == degree
+        assert np.all(result.illumination >= 0)
+        assert np.all(result.illumination <= 1)
+
     def test_spot_diagram(self, a: optika.systems.AbstractSequentialSystem):
         fig, axs = a.spot_diagram()
         assert isinstance(fig, plt.Figure)

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -342,7 +342,12 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(result, optika.radiometry.PolynomialVignettingModel)
         assert result.degree == degree
         assert np.all(result.illumination >= 0)
-        assert np.allclose(result.illumination.mean(result.axis_field), 1)
+        mean = np.mean(
+            result.illumination,
+            axis=result.axis_field,
+            where=result.where,
+        )
+        assert np.allclose(mean, 1)
 
     def test_spot_diagram(self, a: optika.systems.AbstractSequentialSystem):
         fig, axs = a.spot_diagram()


### PR DESCRIPTION
Replaces #183, which GitHub closed when its base branch (`feature/system-distortion`, #181) was squash-merged and deleted; the branch is rebased onto `main` so only the vignetting commits remain.

## Summary

- Add `AbstractSequentialSystem.vignetting()`, the vignetting counterpart of `distortion()`: the relative illumination at each scene coordinate is estimated from the fraction of unvignetted rays in the pupil, normalized so that its average over the field of view is unity, and fit with an `optika.radiometry.PolynomialVignettingModel`.
- Same interface as `distortion()`: custom `wavelength`/`field`/`pupil` grids (traced with `rayfunction()`, so grids left as `None` inherit the corresponding component of `grid_input`), `normalized_field`/`normalized_pupil` flags, polynomial `degree`, and a clear `ValueError` when the wavelength grid has no logical axis.
- The grid resolution and axis normalization shared between the two methods is factored into a private `_rayfunction_and_axes()` helper instead of duplicating ~30 lines.

## Tests

`test_vignetting` mirrors `test_distortion`: parametrized over both grid sources and two polynomial degrees, asserting the model type, degree, the scalar-wavelength error branch, non-negative illumination, and that the illumination averages to unity over the field axes.

`pytest optika/systems/_sequential_test.py -k "test_vignetting or test_distortion"`: 48 passed; `black --check` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc