### PR TITLE
Parametrize the inherited `TestStackLikeFunctions` in the vector tests

### DIFF
--- a/optika/rays/_tests/test_ray_vectors.py
+++ b/optika/rays/_tests/test_ray_vectors.py
@@ -203,6 +203,12 @@ class AbstractTestAbstractRayVectorArray(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
     ):
         @pytest.mark.parametrize("array_2", rays)
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", rays)
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/optika/vectors/_tests/test_vectors_field.py
+++ b/optika/vectors/_tests/test_vectors_field.py
@@ -65,6 +65,12 @@ class AbstractTestAbstractFieldVectorArray(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
     ):
         @pytest.mark.parametrize("array_2", vectors_field)
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", vectors_field)
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/optika/vectors/_tests/test_vectors_object.py
+++ b/optika/vectors/_tests/test_vectors_object.py
@@ -69,6 +69,12 @@ class AbstractTestAbstractObjectVectorArray(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
     ):
         @pytest.mark.parametrize("array_2", vectors_object)
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", vectors_object)
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/optika/vectors/_tests/test_vectors_polarization.py
+++ b/optika/vectors/_tests/test_vectors_polarization.py
@@ -67,6 +67,12 @@ class AbstractTestAbstractPolarizationVectorArray(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
     ):
         @pytest.mark.parametrize("array_2", vectors_polarization)
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", vectors_polarization)
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/optika/vectors/_tests/test_vectors_pupil.py
+++ b/optika/vectors/_tests/test_vectors_pupil.py
@@ -65,6 +65,12 @@ class AbstractTestAbstractPupilVectorArray(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
     ):
         @pytest.mark.parametrize("array_2", vectors_pupil)
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", vectors_pupil)
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/optika/vectors/_tests/test_vectors_scene.py
+++ b/optika/vectors/_tests/test_vectors_scene.py
@@ -63,6 +63,12 @@ class AbstractTestAbstractSceneVectorArray(
         test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
     ):
         @pytest.mark.parametrize("array_2", vectors_scene)
+        class TestStackLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestStackLikeFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize("array_2", vectors_scene)
         class TestAsArrayLikeFunctions(
             test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestAsArrayLikeFunctions
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy!=6.1.5",
-    "named-arrays~=2.0",
+    "named-arrays~=2.1",
     "pymupdf",
     "joblib",
     "ezdxf",


### PR DESCRIPTION
named-arrays now exercises `np.stack` against a second operand in the generic `TestStackLikeFunctions` (sun-data/named-arrays#191, released in the latest named-arrays version), which requires each family test module to parametrize `array_2`. Without this, the optika vector/ray test classes that inherit the named-arrays abstract test chains error with "fixture 'array_2' not found" (16 errors against the new release).

This mirrors the existing `TestAsArrayLikeFunctions` pattern in the six affected modules (`test_vectors_field/object/polarization/pupil/scene`, `test_ray_vectors`), reusing each module's existing instance lists. 28 new stack cases pass; `black` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc