### PR TITLE
Add `SequentialSystem.area_effective` to model the effective area

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1367,6 +1367,150 @@ class AbstractSequentialSystem(
             where=where,
         )
 
+    def area_effective(
+        self,
+        wavelength: None | u.Quantity | na.AbstractScalar = None,
+        field: None | na.AbstractCartesian2dVectorArray = None,
+        pupil: None | na.AbstractCartesian2dVectorArray = None,
+        normalized_field: bool = True,
+        normalized_pupil: bool = True,
+    ) -> optika.radiometry.InterpolatedEffectiveAreaModel:
+        """
+        Estimate the wavelength-dependent effective area of this system by
+        tracing rays through it.
+
+        For each wavelength and field position, rays are traced across the
+        pupil and the throughput of each ray (the product of the efficiency of
+        every surface it encounters: reflectivity, transmissivity, diffraction
+        efficiency, and the absorbance of the sensor) is weighted by the area
+        of its pupil cell and summed, giving the effective area at that field
+        position. Rays blocked by an aperture are excluded from the sum. The
+        result is then averaged over the field of view and returned as an
+        :class:`~optika.radiometry.InterpolatedEffectiveAreaModel`, which
+        linearly interpolates in wavelength.
+
+        The components of `pupil` are interpreted as the vertices of a grid of
+        cells, and the rays are traced at the corresponding cell centers, so
+        that each ray can be weighted by the physical area of its cell.
+
+        The throughput includes the absorbance of the sensor but not its charge
+        collection efficiency, which is applied separately, so this is the
+        effective area up to the absorption of photons in the detector.
+
+        If the object is at infinity, the pupil is measured in units of length
+        and the effective area has units of area (such as :math:`cm^2`). If the
+        object is at a finite distance, the pupil is measured in units of angle
+        and the result instead has units of solid angle (such as
+        :math:`deg^2`).
+
+        Parameters
+        ----------
+        wavelength
+            The wavelengths at which to evaluate the effective area, which must
+            vary along a single logical axis.
+            If :obj:`None` (the default), ``self.grid_input.wavelength``
+            will be used.
+        field
+            The field positions at which the effective area is sampled before
+            averaging over the field of view, in either normalized or physical
+            units.
+            If :obj:`None` (the default), ``self.grid_input.field``
+            will be used.
+        pupil
+            The **vertices** of the pupil grid, in either normalized or physical
+            units. The area of each pupil cell is computed from these vertices
+            and used to weight the throughput, and the rays are traced at the
+            cell centers.
+            If :obj:`None` (the default), an :math:`11 \\times 11` grid spanning
+            the normalized pupil is used.
+        normalized_field
+            A boolean flag indicating whether the `field` parameter is given
+            in normalized or physical units.
+        normalized_pupil
+            A boolean flag indicating whether the `pupil` parameter is given
+            in normalized or physical units.
+
+        Raises
+        ------
+        ValueError
+            If the wavelength grid does not vary along a single logical axis.
+        """
+        if wavelength is None:
+            wavelength = self.grid_input.wavelength
+        if field is None:
+            field = self.grid_input.field
+        if pupil is None:
+            pupil = na.Cartesian2dVectorArray(
+                x=na.linspace(-1, 1, axis="_pupil_x", num=11),
+                y=na.linspace(-1, 1, axis="_pupil_y", num=11),
+            )
+
+        grid = optika.vectors.ObjectVectorArray(
+            wavelength=wavelength,
+            field=field,
+            pupil=pupil,
+        )
+
+        grid = self._denormalize_grid(
+            grid=grid,
+            normalized_field=normalized_field,
+            normalized_pupil=normalized_pupil,
+        )
+
+        wavelength = grid.wavelength
+        field = grid.field
+        pupil = grid.pupil
+
+        axis_wavelength = self._normalize_axis_wavelength(
+            axis_wavelength=None,
+            wavelength=wavelength,
+        )
+        axis_field = self._normalize_axis_field(
+            axis_field=None,
+            axis_wavelength=axis_wavelength,
+            field=field,
+        )
+        axis_pupil = self._normalize_axis_pupil(
+            axis_pupil=None,
+            axis_field=axis_field,
+            axis_wavelength=axis_wavelength,
+            pupil=pupil,
+        )
+
+        if len(axis_wavelength) != 1:
+            raise ValueError(
+                "Computing the effective area requires that there be only "
+                f"one wavelength axis, got {axis_wavelength}"
+            )
+        (axis_wavelength,) = axis_wavelength
+
+        shape = grid.shape
+
+        area = np.abs(pupil.volume_cell(axis=axis_pupil))
+        pupil = pupil.broadcast_to(shape).cell_centers(axis=axis_pupil, random=True)
+
+        rays = self.rayfunction(
+            intensity=area,
+            wavelength=wavelength,
+            field=field,
+            pupil=pupil,
+            normalized_field=False,
+            normalized_pupil=False,
+        )
+
+        area_eff = rays.outputs.intensity.sum(
+            axis=axis_pupil,
+            where=rays.outputs.unvignetted,
+        )
+
+        area_eff = area_eff.mean(axis_field)
+
+        return optika.radiometry.InterpolatedEffectiveAreaModel(
+            wavelength=wavelength,
+            area=area_eff,
+            axis_wavelength=axis_wavelength,
+        )
+
     def _rayfunction_and_axes(
         self,
         wavelength: None | u.Quantity | na.AbstractScalar = None,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -349,6 +349,58 @@ class AbstractTestAbstractSequentialSystem(
         )
         assert np.allclose(mean, 1)
 
+    @pytest.mark.parametrize(
+        argnames="wavelength,field,pupil",
+        argvalues=[
+            (
+                None,
+                None,
+                None,
+            ),
+            (
+                na.linspace(500, 600, axis="wavelength", num=3) * u.nm,
+                na.Cartesian2dVectorLinearSpace(
+                    start=-1,
+                    stop=1,
+                    axis=na.Cartesian2dVectorArray("field_x", "field_y"),
+                    num=5,
+                ),
+                na.Cartesian2dVectorLinearSpace(
+                    start=-1,
+                    stop=1,
+                    axis=na.Cartesian2dVectorArray("pupil_x", "pupil_y"),
+                    num=5,
+                ),
+            ),
+        ],
+    )
+    def test_area_effective(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+        wavelength: None | u.Quantity | na.AbstractScalar,
+        field: None | na.AbstractCartesian2dVectorArray,
+        pupil: None | na.AbstractCartesian2dVectorArray,
+    ):
+        if wavelength is None and not a.axis_wavelength_:
+            with pytest.raises(ValueError):
+                a.area_effective(
+                    wavelength=wavelength,
+                    field=field,
+                    pupil=pupil,
+                )
+            return
+        result = a.area_effective(
+            wavelength=wavelength,
+            field=field,
+            pupil=pupil,
+        )
+        assert isinstance(result, optika.radiometry.InterpolatedEffectiveAreaModel)
+        if a.object_is_at_infinity:
+            assert na.unit(result.area).is_equivalent(u.cm**2)
+        else:
+            assert na.unit(result.area).is_equivalent(u.deg**2)
+        assert np.all(result.area >= 0)
+
     def test_spot_diagram(self, a: optika.systems.AbstractSequentialSystem):
         fig, axs = a.spot_diagram()
         assert isinstance(fig, plt.Figure)


### PR DESCRIPTION
## Summary

Adds `SequentialSystem.area_effective`, which estimates the wavelength-dependent effective area of a sequential system by ray tracing.

For each wavelength and field position, rays are traced across the pupil and each ray's throughput (the product of the efficiency of every surface it encounters: reflectivity, transmissivity, diffraction efficiency, and the absorbance of the sensor) is weighted by the area of its pupil cell and summed, giving the effective area at that field position. Rays blocked by an aperture are excluded. The result is averaged over the field of view and returned as an `InterpolatedEffectiveAreaModel`.

## Details

- **Pupil as vertices.** The components of `pupil` are interpreted as the vertices of a grid of cells, and rays are traced at the corresponding cell centers, so each ray can be weighted by the physical area of its cell (`volume_cell` on the vertices). Cell centers are drawn with stratified random offsets (`random=True`), which converges faster than midpoint sampling because the throughput is discontinuous at the vignetting edge.
- **Throughput scope.** Includes the absorbance of the sensor but not its charge collection efficiency, which is applied separately, so this is the effective area up to the absorption of photons in the detector.
- **Units.** For an object at infinity the pupil is measured in length and the result has units of area (e.g. cm^2); for a finite-conjugate object the pupil is angular and the result has units of solid angle (e.g. deg^2).
- Fails fast with a `ValueError` if the wavelength grid does not vary along a single logical axis, before any ray tracing.

## Tests

Adds `test_area_effective` to `AbstractTestAbstractSequentialSystem`, mirroring the `distortion`/`vignetting` parametrization across all system fixtures. Asserts the returned model type, non-negative area, correct units per object conjugate (cm^2 at infinity, deg^2 finite), and the single-wavelength-axis `ValueError`. Full `optika/systems/_sequential_test.py` suite passes locally (435 passed); `black` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdKmedevWkDab6BWupXqQ