### PR TITLE
Add a `read_noise` parameter to the imaging sensor

### DIFF
--- a/optika/sensors/_sensors.py
+++ b/optika/sensors/_sensors.py
@@ -73,14 +73,12 @@ class AbstractImagingSensor(
         """
 
     @property
+    @abc.abstractmethod
     def read_noise(self) -> u.Quantity | na.AbstractScalar:
         """
         The standard deviation of the Gaussian read noise added to each pixel
         during readout, in electrons.
-
-        Defaults to zero; concrete sensors may override it.
         """
-        return 0 * u.electron
 
     @property
     def aperture(self):

--- a/optika/sensors/_sensors.py
+++ b/optika/sensors/_sensors.py
@@ -73,6 +73,16 @@ class AbstractImagingSensor(
         """
 
     @property
+    def read_noise(self) -> u.Quantity | na.AbstractScalar:
+        """
+        The standard deviation of the Gaussian read noise added to each pixel
+        during readout, in electrons.
+
+        Defaults to zero; concrete sensors may override it.
+        """
+        return 0 * u.electron
+
+    @property
     def aperture(self):
         """
         The light-sensitive aperture of the sensor.
@@ -208,7 +218,8 @@ class AbstractImagingSensor(
             If :obj:`None` (the default), the value in :attr:`timedelta_exposure`
             will be used.
         noise
-            Whether to add shot noise and intrinsic sensor noise to the result.
+            Whether to add shot noise, intrinsic sensor noise, and read noise
+            to the result.
         """
         if axis_wavelength is None:
             shape_wavelength = na.shape(image.inputs.wavelength)
@@ -232,6 +243,13 @@ class AbstractImagingSensor(
             axis_xy=(self.axis_pixel.x, self.axis_pixel.y),
             noise=noise,
         )
+
+        if noise:
+            # add zero-mean Gaussian read noise to each pixel
+            electrons = na.random.normal(
+                loc=electrons,
+                scale=self.read_noise,
+            )
 
         return dataclasses.replace(image, outputs=electrons)
 
@@ -314,10 +332,11 @@ class AbstractImagingSensor(
         Compute the standard deviation of the noise in an image of electrons
         measured by the sensor.
 
-        This uses the material's analytic noise model
+        This combines the material's analytic noise model
         (:meth:`~optika.sensors.materials.AbstractSensorMaterial.uncertainty`),
-        which accounts for shot, Fano, and partial-charge-collection noise, and
-        so is the deterministic counterpart of the noise added by :meth:`expose`.
+        which accounts for shot, Fano, and partial-charge-collection noise, with
+        the sensor's :attr:`read_noise` (added in quadrature), and so is the
+        deterministic counterpart of the noise added by :meth:`expose`.
 
         Parameters
         ----------
@@ -348,6 +367,9 @@ class AbstractImagingSensor(
             wavelength=image.inputs.wavelength.cell_centers(axis_wavelength),
             direction=direction,
         )
+
+        # add the read noise in quadrature
+        uncertainty = np.sqrt(np.square(uncertainty) + np.square(self.read_noise))
 
         return dataclasses.replace(image, outputs=uncertainty)
 
@@ -435,6 +457,12 @@ class ImagingSensor(
     timedelta_exposure: u.Quantity | na.AbstractScalar = 0 * u.s
     """The exposure time of the sensor."""
 
+    read_noise: u.Quantity | na.AbstractScalar = 0 * u.electron
+    """
+    The standard deviation of the Gaussian read noise added to each pixel
+    during readout, in electrons.
+    """
+
     material: AbstractSensorMaterial = None
     """
     A model of the light-sensitive material composing this sensor.
@@ -469,5 +497,6 @@ class ImagingSensor(
             optika.shape(self.width_pixel),
             optika.shape(self.num_pixel),
             optika.shape(self.timedelta_exposure),
+            optika.shape(self.read_noise),
             optika.shape(self.transformation),
         )

--- a/optika/sensors/_sensors_test.py
+++ b/optika/sensors/_sensors_test.py
@@ -20,6 +20,10 @@ class AbstractTestAbstractImagingSensor(
         result = a.timedelta_exposure
         assert result >= 0 * u.s
 
+    def test_read_noise(self, a: optika.sensors.AbstractImagingSensor):
+        result = a.read_noise
+        assert result >= 0 * u.electron
+
     @pytest.mark.parametrize(
         argnames="rays",
         argvalues=[
@@ -158,7 +162,8 @@ class AbstractTestAbstractImagingSensor(
         assert isinstance(result, na.FunctionArray)
         assert isinstance(result.inputs, na.SpectralPositionalVectorArray)
         assert result.outputs.unit.is_equivalent(u.electron)
-        assert np.all(result.outputs >= 0 * u.electron)
+        # the total noise is at least the read noise (added in quadrature)
+        assert np.all(result.outputs >= a.read_noise)
 
 
 @pytest.mark.parametrize(
@@ -169,6 +174,7 @@ class AbstractTestAbstractImagingSensor(
             width_pixel=15 * u.um,
             axis_pixel=na.Cartesian2dVectorArray("detector_x", "detector_y"),
             num_pixel=na.Cartesian2dVectorArray(2048, 1024),
+            read_noise=4 * u.electron,
             transformation=na.transformations.Cartesian3dTranslation(x=1 * u.mm),
         ),
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ Homepage = "https://github.com/sun-data/optika"
 Documentation = "https://optika.readthedocs.io/en/latest"
 
 [tool.setuptools_scm]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
Adds a `read_noise` parameter to the imaging sensor — the standard deviation of the Gaussian read noise added to each pixel during readout.

- `AbstractImagingSensor.read_noise` is a property defaulting to `0 electron` (so existing/external sensors are unaffected), with a corresponding field on `ImagingSensor`.
- `expose` adds zero-mean Gaussian read noise to the measured electrons when `noise=True` (verified by Monte Carlo: √(shot² + read²)).
- `uncertainty` adds the read noise in quadrature with the material's shot/Fano/partial-charge-collection noise.

New `test_read_noise` plus read-noise coverage in the `expose`/`uncertainty` tests. It flows automatically into `LinearSystem.image(uncertainty=True)` and its consumers, since those delegate to the sensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)