### PR TITLE
Fix the effective-area unit stripped by the linear-system weights

### DIFF
--- a/optika/systems/_linear.py
+++ b/optika/systems/_linear.py
@@ -194,7 +194,9 @@ class AbstractLinearSystem(
 
         weights_area = self.area_effective(coordinates_cell.wavelength)
 
-        weights_input = weights_vignetting * weights_stop * weights_area.value
+        weights_input = (
+            weights_vignetting * weights_stop * weights_area.to_value(self.weights_unit)
+        )
 
         axis_pixel = self.sensor.axis_pixel
 
@@ -252,7 +254,7 @@ class AbstractLinearSystem(
 
         weights_area = self.area_effective(coordinates_cell.wavelength)
 
-        weights_input = weights_vignetting * weights_area.value
+        weights_input = weights_vignetting * weights_area.to_value(self.weights_unit)
 
         axis_pixel = self.sensor.axis_pixel
 

--- a/optika/systems/_linear_test.py
+++ b/optika/systems/_linear_test.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import pytest
 import numpy as np
 import astropy.units as u
@@ -190,6 +192,25 @@ class AbstractTestAbstractLinearSystem(
             u.photon / u.s / u.cm**2 / u.arcsec**2 / u.nm
         )
         assert np.all(np.isfinite(result.outputs.value))
+
+    def test_image_area_unit_invariance(
+        self,
+        a: optika.systems.AbstractLinearSystem,
+    ):
+        # the result must not depend on the unit the effective area model
+        # happens to be expressed in, since `weights` strips the unit and
+        # `image_from_weights` restores it as `weights_unit`
+        area = a.area_effective
+        if not hasattr(area, "area"):  # pragma: nocover
+            pytest.skip("requires an area model with an `area` attribute")
+        b = dataclasses.replace(
+            a,
+            area_effective=dataclasses.replace(area, area=area.area.to(u.mm**2)),
+        )
+        scene = _scene(1e3 * u.photon / u.s / u.cm**2 / u.arcsec**2 / u.nm)
+        result_a = a.image(scene, noise=False)
+        result_b = b.image(scene, noise=False)
+        assert np.allclose(result_a.outputs, result_b.outputs)
 
     def test_image_uncertainty(self, a: optika.systems.AbstractLinearSystem):
         scene = _scene(1e3 * u.photon / u.s / u.cm**2 / u.arcsec**2 / u.nm)


### PR DESCRIPTION
## Summary

`AbstractLinearSystem.weights` and `weights_transposed` strip the unit of the effective area with `.value` before handing the weights to `na.regridding`, while `image_from_weights`/`backproject_from_weights` restore that unit as the hardcoded `weights_unit` (`u.cm**2`). If the effective-area model happens to evaluate in any other unit, every forward image is silently wrong by the unit ratio — the ESIS-II instrument model evaluates in mm², making `LinearSystem.image` exactly 100× too bright relative to the raytraced `SequentialSystem.image`.

This converts with `area.to_value(self.weights_unit)` instead, so the stripped number is always in the unit that gets restored.

## Test

Adds `test_image_area_unit_invariance` to `AbstractTestAbstractLinearSystem`: imaging the same scene must give identical results when the effective-area model is re-expressed in mm². Fails at 100× on the base branch, passes with the fix.

After the fix, `LinearSystem.image` and `SequentialSystem.image` agree to within the degree-2 vignetting-fit residual (~20%) on an ESIS-II test scene, instead of two orders of magnitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)